### PR TITLE
Increase max text size by 50%

### DIFF
--- a/BiggerNotes/UI/TextSettingsSheet.swift
+++ b/BiggerNotes/UI/TextSettingsSheet.swift
@@ -28,39 +28,36 @@ struct TextSettingsSheet: View {
             Form {
                 // Font options
                 Section {
+                    // Text size
                     VStack {
-                        // Text size
-                        HStack {
-                            Text("Aa")
-                                .font(textSettingsViewModel.font(size: TextSettingsViewModel.MinTextSize, weight: textSettingsViewModel.textWeight.instance))
-                            Slider(
-                                value: $textSettingsViewModel.textSize,
-                                in: TextSettingsViewModel.MinTextSize...TextSettingsViewModel.MaxTextSize
-                            )
-                            Text("Aa")
-                                .font(textSettingsViewModel.font(size: TextSettingsViewModel.MaxTextSize, weight: textSettingsViewModel.textWeight.instance))
-                        }
-                        .frame(height: TextSettingsViewModel.MaxTextSize + 20)
+                        Text("Hi")
+                            .font(textSettingsViewModel.font(size: textSettingsViewModel.textSize, weight: textSettingsViewModel.textWeight.instance))
+                            .baselineOffset(-10)
+                            .frame(height: TextSettingsViewModel.MaxTextSize)
+                        Slider(
+                            value: $textSettingsViewModel.textSize,
+                            in: TextSettingsViewModel.MinTextSize...TextSettingsViewModel.MaxTextSize
+                        )
+                    }
 
-                        // Text weight
-                        Picker("Text Weight", selection: $textSettingsViewModel.textWeight) {
-                            ForEach(NoteTextWeight.allCases) { option in
-                                Text(option.rawValue).tag(option)
-                            }
+                    // Text weight
+                    Picker("Text Weight", selection: $textSettingsViewModel.textWeight) {
+                        ForEach(NoteTextWeight.allCases) { option in
+                            Text(option.rawValue).tag(option)
                         }
-                        .pickerStyle(.segmented)
                     }
-                    VStack {
-                        // Font
-                        Picker("Font", selection: $textSettingsViewModel.fontName) {
-                            ForEach(TextSettingsViewModel.availableFonts, id: \.self) { option in
-                                Text(option)
-                                    .tag(option)
-                            }
+                    .pickerStyle(.segmented)
+                    
+                    // Font
+                    Picker("Font", selection: $textSettingsViewModel.fontName) {
+                        ForEach(TextSettingsViewModel.availableFonts, id: \.self) { option in
+                            Text(option)
+                                .tag(option)
                         }
-                        .pickerStyle(.automatic)
                     }
+                    .pickerStyle(.automatic)
                 }
+                .listRowSeparator(.hidden)
 
                 // Color
                 Section {

--- a/BiggerNotes/UI/TextSettingsSheet.swift
+++ b/BiggerNotes/UI/TextSettingsSheet.swift
@@ -32,7 +32,6 @@ struct TextSettingsSheet: View {
                     VStack {
                         Text("Hi")
                             .font(textSettingsViewModel.font(size: textSettingsViewModel.textSize, weight: textSettingsViewModel.textWeight.instance))
-                            .baselineOffset(-10)
                             .frame(height: TextSettingsViewModel.MaxTextSize)
                         Slider(
                             value: $textSettingsViewModel.textSize,

--- a/BiggerNotes/UI/TextSettingsViewModel.swift
+++ b/BiggerNotes/UI/TextSettingsViewModel.swift
@@ -86,7 +86,6 @@ class TextSettingsViewModel: ObservableObject {
         "Menlo",
         "Noteworthy",
         "Optima",
-        "Rockwell",
     ]
 }
 

--- a/BiggerNotes/UI/TextSettingsViewModel.swift
+++ b/BiggerNotes/UI/TextSettingsViewModel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 class TextSettingsViewModel: ObservableObject {
     static let MinTextSize = 20.0
-    static let MaxTextSize = 80.0
+    static let MaxTextSize = 120.0
     static let DefaultTextSize = 50.0
     static let DefaultTextWeight = NoteTextWeight.semibold
     static let DefaultFont = "System"


### PR DESCRIPTION
- The max text size is now 120 instead of 80
- Rework the text settings sheet to accommodate the larger text
- Remove Rockwell as a font option because its baseline causes some rendering issues