### PR TITLE
Hide empty notes from the note list

### DIFF
--- a/BiggerNotes.xcodeproj/project.pbxproj
+++ b/BiggerNotes.xcodeproj/project.pbxproj
@@ -424,7 +424,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.1;
+				MARKETING_VERSION = 3.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ejeff.BiggerNotes;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -456,7 +456,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.1;
+				MARKETING_VERSION = 3.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.ejeff.BiggerNotes;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/BiggerNotes/UI/NoteList.swift
+++ b/BiggerNotes/UI/NoteList.swift
@@ -19,6 +19,7 @@ struct NoteList: View {
             NSSortDescriptor(keyPath: \Note.favorite, ascending: false),
             NSSortDescriptor(keyPath: \Note.modified, ascending: false)
         ],
+        predicate: NSPredicate(format: "content != ''"),
         animation: .default
     )
     var notes: SectionedFetchResults<String, Note>


### PR DESCRIPTION
The only time an empty note would show up in the note list is if the user returns from editing a note and leaves it blank. At that point, it gets pruned anyway. To reduce motion/animation from the prune, hide empty notes to begin with so that there is no apparent change when the user returns to the note list from an empty note.