### PR TITLE
Remove a workaround for a SwiftUI issue that is no longer required

### DIFF
--- a/BiggerNotes/UI/AppSettingsSheet.swift
+++ b/BiggerNotes/UI/AppSettingsSheet.swift
@@ -36,12 +36,9 @@ struct AppSettingsSheet: View {
                 
                 Section {
                     Button {
+                        appSettingsViewModel.resetToDefaults()
                     } label: {
                         Text("Reset to defaults")
-                    }.onTapGesture {
-                        // Executing this in onTapGesture instead of the button action is a workaround to avoid modifying state during view rendering
-                        // Reference: https://www.hackingwithswift.com/quick-start/swiftui/how-to-fix-modifying-state-during-view-update-this-will-cause-undefined-behavior
-                        appSettingsViewModel.resetToDefaults()
                     }
                 }
                 


### PR DESCRIPTION
SwiftUI used to warn that the action that restores the app settings to defaults could result in undefined behavior. This seems to have been fixed recently, so the workaround can be removed and the reset button can perform the action normally.