### PR TITLE
Remove state modification workaround

### DIFF
--- a/BiggerNotes/UI/TextSettingsSheet.swift
+++ b/BiggerNotes/UI/TextSettingsSheet.swift
@@ -67,12 +67,9 @@ struct TextSettingsSheet: View {
                 
                 // Reset
                 Button {
+                    textSettingsViewModel.resetToDefaults()
                 } label: {
                     Text("Reset to defaults")
-                }.onTapGesture {
-                    // Executing this in onTapGesture instead of the button action is a workaround to avoid modifying state during view rendering
-                    // Reference: https://www.hackingwithswift.com/quick-start/swiftui/how-to-fix-modifying-state-during-view-update-this-will-cause-undefined-behavior
-                    textSettingsViewModel.resetToDefaults()
                 }
             }
         }


### PR DESCRIPTION
This `onTapGesture` workaround is no longer needed, probably because of recent changes to the `TextView`. Text settings can now be reset to default without causing undesired behavior in the view.